### PR TITLE
Define that NVM_PATH is for nvm

### DIFF
--- a/bin/install.cmd
+++ b/bin/install.cmd
@@ -1,5 +1,5 @@
 @echo off
-set /P NVM_PATH="Enter the absolute path where the zip file is extracted/copied to: "
+set /P NVM_PATH="Enter the absolute path where the nvm-windows zip file is extracted/copied to: "
 set NVM_HOME=%NVM_PATH%
 set NVM_SYMLINK=C:\Program Files\nodejs
 setx /M NVM_HOME "%NVM_HOME%"


### PR DESCRIPTION
This message is vague and can pop-up on other places, not only when using nvm-windows directly.

I've added message clarification so if it pops-up, it's clear that this is nvm.